### PR TITLE
Fix lua errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+    "Lua.runtime.version": "Lua 5.1",
+    "Lua.runtime.builtin": {
+        "basic": "disable",
+        "debug": "disable",
+        "io": "disable",
+        "math": "disable",
+        "os": "disable",
+        "package": "disable",
+        "string": "disable",
+        "table": "disable",
+        "utf8": "disable"
+    },
+    "Lua.workspace.library": [
+        "~\\.vscode\\extensions\\ketho.wow-api-0.21.0\\Annotations\\Core"
+    ],
+    "Lua.diagnostics.globals": [
+        "UIDropDownMenu_SetSelectedID",
+        "UIDropDownMenu_Initialize",
+        "UIDropDownMenu_AddButton",
+        "UIDropDownMenu_SetSelectedValue",
+        "UISpecialFrames",
+        "UIDropDownMenu_CreateInfo",
+        "UIDropDownMenu_GetSelectedValue",
+        "SlashCmdList",
+        "DEFAULT_CHAT_FRAME",
+        "CHAT_TELL_ALERT_TIME",
+        "ChatEdit_SetLastTellTarget",
+        "ChatFrame_OnEvent"
+    ]
+}

--- a/ChatSounds.lua
+++ b/ChatSounds.lua
@@ -45,10 +45,10 @@ local function ChatSounds_Slasher(cmd)
 		cmd = string.lower(cmd)
 		if ChatSounds_Config[ChatSounds_Player].Blacklist[cmd] then
 			ChatSounds_Config[ChatSounds_Player].Blacklist[cmd] = nil
-			DEFAULT_CHAT_FRAME:AddMessage(ChatSounds_label..", cmd .. " removed from Blacklist.");
+			DEFAULT_CHAT_FRAME:AddMessage(ChatSounds_label..": ".. cmd .. " removed from Blacklist.");
 		else
 			ChatSounds_Config[ChatSounds_Player].Blacklist[cmd] = true
-			DEFAULT_CHAT_FRAME:AddMessage(ChatSounds_label..", cmd .. " added to Blacklist.");
+			DEFAULT_CHAT_FRAME:AddMessage(ChatSounds_label..": ".. cmd .. " added to Blacklist.");
 		end
 	end
 end

--- a/ChatSounds.lua
+++ b/ChatSounds.lua
@@ -57,19 +57,7 @@ function ChatSounds_OnLoad(self)
 
 	-- Register Variable Loading and Chat Events.
 	self:RegisterEvent("ADDON_LOADED")
--- 	self:RegisterEvent("CHAT_MSG_WHISPER")
--- 	self:RegisterEvent("CHAT_MSG_WHISPER_INFORM")
--- 	self:RegisterEvent("CHAT_MSG_BN_WHISPER")
--- 	self:RegisterEvent("CHAT_MSG_BN_WHISPER_INFORM")
-	self:RegisterEvent("CHAT_MSG_GUILD")
-	self:RegisterEvent("CHAT_MSG_OFFICER")
-	self:RegisterEvent("CHAT_MSG_PARTY")
-	self:RegisterEvent("CHAT_MSG_PARTY_LEADER")
-	self:RegisterEvent("CHAT_MSG_RAID")
-	self:RegisterEvent("CHAT_MSG_RAID_LEADER")
-	self:RegisterEvent("CHAT_MSG_INSTANCE_CHAT")
-	self:RegisterEvent("CHAT_MSG_INSTANCE_CHAT_LEADER")
-	self:RegisterEvent("CHAT_MSG_CHANNEL")
+	self:RegisterEvent("PLAYER_LOGIN")
 	
 	-- Register Slash Command.
 	SLASH_CHATSOUNDS1 = "/chatsounds"
@@ -147,6 +135,11 @@ end
 -- Chat message filter for WoW 12.0+ API
 function ChatSounds_ChatMessageFilter(frame, event, message, sender, languageName, channelName, ...)
 	local msgtype = string.sub(event, 10)
+	
+	-- Skip if config not ready yet
+	if not ChatSounds_Config or not ChatSounds_Config[ChatSounds_Player] then
+		return false
+	end
 	
 	if msgtype == "CHANNEL" then
 		-- Get additional args specific to CHAT_MSG_CHANNEL

--- a/ChatSounds.lua
+++ b/ChatSounds.lua
@@ -5,8 +5,9 @@ ChatSounds_Config  = ChatSounds_Config or {}
 local ChatSounds_label = "|cffFFCC00ChatSounds|r";
 
 local function ChatSounds_Slasher(cmd)
+	ChatSounds_InitConfig()
 	if not cmd or cmd == "" then
-		ChatSoundsOptionsFrame_Show(ChatSoundsOptionsFrame)
+		ChatSoundsOptionsFrame_Show()
 		DEFAULT_CHAT_FRAME:AddMessage(ChatSounds_label..": '/chatsounds ?' or '/chatsounds !help' for other commands.");
 	elseif string.lower(cmd) == "!help" or cmd == "?" then
 		DEFAULT_CHAT_FRAME:AddMessage(ChatSounds_label.." ".. ChatSounds_Version);
@@ -182,4 +183,13 @@ function ChatSounds_ChatFrame_OnEvent (self, event, ...)
 		ChatSounds_PlaySound (ChatSounds_Config[ChatSounds_Player].Outgoing["BNWHISPER"])
 	end
 
+end
+
+function ChatSoundsOptionsFrame_Show()
+	if ChatSoundsOptionsFrame and InterfaceOptionsFrame_OpenToCategory then
+		InterfaceOptionsFrame_OpenToCategory(ChatSoundsOptionsFrame)
+		InterfaceOptionsFrame_OpenToCategory(ChatSoundsOptionsFrame)
+	elseif ChatSoundsOptionsFrame then
+		ChatSoundsOptionsFrame:Show()
+	end
 end

--- a/ChatSounds.lua
+++ b/ChatSounds.lua
@@ -3,6 +3,16 @@ ChatSounds_Player  = "player"
 ChatSounds_Config  = ChatSounds_Config or {}
 
 local ChatSounds_label = "|cffFFCC00ChatSounds|r";
+local chatFrameHooked = false
+
+local function ChatSounds_TryHookChatFrame()
+	if (not chatFrameHooked) and type(ChatFrame_OnEvent) == "function" then
+		hooksecurefunc("ChatFrame_OnEvent", ChatSounds_ChatFrame_OnEvent)
+		chatFrameHooked = true
+		return true
+	end
+	return false
+end
 
 local function ChatSounds_Slasher(cmd)
 	ChatSounds_InitConfig()
@@ -111,10 +121,17 @@ function ChatSounds_OnEvent(self, event, ...)
 	if (event == "ADDON_LOADED" and arg1 == "ChatSounds" ) then
 
 		ChatSounds_InitConfig();
- 		hooksecurefunc("ChatFrame_OnEvent", ChatSounds_ChatFrame_OnEvent);
+		if not ChatSounds_TryHookChatFrame() then
+			self:RegisterEvent("PLAYER_LOGIN")
+		end
 		-- ChatSounds are now loaded!
 		DEFAULT_CHAT_FRAME:AddMessage(ChatSounds_label.." ".. ChatSounds_Version .. " are loaded.");
 		self:UnregisterEvent("ADDON_LOADED");
+
+	elseif (event == "PLAYER_LOGIN") then
+		if ChatSounds_TryHookChatFrame() then
+			self:UnregisterEvent("PLAYER_LOGIN")
+		end
 
 	elseif (strsub (event, 1, 8) == "CHAT_MSG") then
 		local msgtype = strsub (event, 10)

--- a/ChatSounds.toc
+++ b/ChatSounds.toc
@@ -1,7 +1,7 @@
-## Interface: 90001
+## Interface: 120000
 ## Title: ChatSounds
 ## Author: Cashrodiirn
-## Version: v2.9.0
+## Version: v2.9.1
 ## X-Credits: Cashrodiirn, Driizt (Previous Author), AlmostConnected (Original Author), Chochol (Shadowlands changes) 
 ## Notes: Enables user defined sounds for Party, Guild, Raid and Custom Channel chat messages.
 ## SavedVariables: ChatSounds_Config

--- a/ChatSounds.txt
+++ b/ChatSounds.txt
@@ -16,10 +16,15 @@
 -WoW 2.0 and Burning Crusade compatibility update
 
 0.10 to 0.10.1 (11200) notes
+
+2025.11.28 (90001) notes
+===============================================
+- migrated the options frame into the Interface Options system and ensured `/chatsounds` opens the correct panel under the current API.
+- replaced the deprecated button/checkbutton templates and removed unsupported XML nodes so the frame loads without schema errors.
+- guarded the bag button helpers and text widgets, and refreshed configuration state before showing/saving settings to avoid nil globals.
 ===============================================
 -Added several new sounds and changed around defaults.
 -Internal game sounds no longer selectable in dropdowns.
-(can be reactivated by uncommenting them in SoundList.lua)
 -Title in addons game menu updated to match the addon version.
 
 0.9 to 0.10 (11200) notes

--- a/ChatSounds.xml
+++ b/ChatSounds.xml
@@ -6,7 +6,7 @@
 	<Script file="ChatSounds.lua"/>
 	<Script file="ChatSoundsOptionsFrame.lua"/>
 
-	<Frame name="ChatSoundsFrame" inherits="EventFrame">
+	<Frame name="ChatSoundsFrame">
 		<Scripts>
 			<OnLoad>
 				ChatSounds_OnLoad(self);

--- a/ChatSounds.xml
+++ b/ChatSounds.xml
@@ -6,13 +6,13 @@
 	<Script file="ChatSounds.lua"/>
 	<Script file="ChatSoundsOptionsFrame.lua"/>
 
-	<Frame name="ChatSoundsFrame">
+	<Frame name="ChatSoundsFrame" inherits="EventFrame">
 		<Scripts>
 			<OnLoad>
 				ChatSounds_OnLoad(self);
 			</OnLoad>
 			<OnEvent>
- 				ChatSounds_OnEvent(self, event, ...);
+				ChatSounds_OnEvent(self, event, ...);
 			</OnEvent>
 		</Scripts>
 	</Frame>

--- a/ChatSoundsOptionsFrame.lua
+++ b/ChatSoundsOptionsFrame.lua
@@ -12,11 +12,9 @@ groupmap[10] = "BNWHISPER"
 groupmap[11] = "CHANNEL"
 
 function ChatSoundsDropDown_OnShow (self)
-	UIDropDownMenu_SetSelectedID(self, 1, 0)
-	UIDropDownMenu_Initialize(self, ChatSoundsDropDown_Init)
-end
+	local menu = {text = "ChatSounds Sounds", whileDead = 1, isNotSelectable = true}
+	menu.func = ChatSoundsDropDown_OnClick
 
-function ChatSoundsDropDown_Init(self)
 	local sound = {}
 	local i = 1
 	for name, value in pairs(ChatSounds_Sound) do
@@ -24,35 +22,23 @@ function ChatSoundsDropDown_Init(self)
 		i = i + 1
 	end
 
-	table.sort (sound)
+	table.sort(sound)
 
-	local entry;
-	entry = UIDropDownMenu_CreateInfo();
+	-- Add "None" option
+	table.insert(menu, {text = "None", value = nil, func = ChatSoundsDropDown_OnClick})
 
-	entry.text    = "None"
-	entry.value   = nil
-	entry.func    = ChatSoundsDropDown_OnClick
-	entry.checked = false
-	entry.owner   = self
-
-	UIDropDownMenu_AddButton(entry)
-
+	-- Add all sounds
 	for index, value in pairs(sound) do
-
-		entry.text    = value
-		entry.value   = value
-		entry.func    = ChatSoundsDropDown_OnClick
-		entry.checked = false
-		entry.owner   = self
-
-		UIDropDownMenu_AddButton(entry)
+		table.insert(menu, {text = value, value = value, func = ChatSoundsDropDown_OnClick})
 	end
 
+	UIDropDownMenu_Initialize(self, function() UIDropDownMenu_AddButtons(menu) end, "MENU")
 end
 
 function ChatSoundsDropDown_OnClick(self)
-	UIDropDownMenu_SetSelectedValue(self.owner, self.value, 0);
-	ChatSounds_PlaySound(self.value);
+	if self.value then
+		ChatSounds_PlaySound(self.value)
+	end
 end
 
 function ChatSoundsOptionsFrame_OnLoad (self)
@@ -66,7 +52,10 @@ function ChatSoundsOptionsFrame_OnLoad (self)
 	self.default = ChatSoundsOptionsFrame_OnDefaults
 	self.refresh = ChatSoundsOptionsFrame_OnShow
 
-	if InterfaceOptions_AddCategory then
+	if Settings and Settings.RegisterCanvasLayoutCategory then
+		local category = Settings.RegisterCanvasLayoutCategory(self, self.name)
+		Settings.RegisterAddOnCategory(category)
+	elseif InterfaceOptions_AddCategory then
 		InterfaceOptions_AddCategory(self)
 	end
 end
@@ -78,8 +67,20 @@ function ChatSoundsOptionsFrame_OnShow(self)
 		local incoming = _G["ChatSoundsOptionsFrameGroup"..i.."Incoming"]
 		local outgoing = _G["ChatSoundsOptionsFrameGroup"..i.."Outgoing"]
 
-		UIDropDownMenu_SetSelectedValue(incoming, playerConfig.Incoming[groupmap[i]], 0)
-		UIDropDownMenu_SetSelectedValue(outgoing, playerConfig.Outgoing[groupmap[i]], 0)
+		if incoming then
+			if incoming.SetValue then
+				incoming:SetValue(playerConfig.Incoming[groupmap[i]])
+			else
+				UIDropDownMenu_SetSelectedValue(incoming, playerConfig.Incoming[groupmap[i]], 0)
+			end
+		end
+		if outgoing then
+			if outgoing.SetValue then
+				outgoing:SetValue(playerConfig.Outgoing[groupmap[i]])
+			else
+				UIDropDownMenu_SetSelectedValue(outgoing, playerConfig.Outgoing[groupmap[i]], 0)
+			end
+		end
 	end
 
 	ChatSoundsOptionsFrameForceWhispersCheckBox:SetChecked (playerConfig.ForceWhispers)
@@ -96,8 +97,20 @@ function ChatSoundsOptionsFrame_OnOkay(self)
 		local incoming = _G["ChatSoundsOptionsFrameGroup"..i.."Incoming"]
 		local outgoing = _G["ChatSoundsOptionsFrameGroup"..i.."Outgoing"]
 
-		playerConfig.Incoming[groupmap[i]] = UIDropDownMenu_GetSelectedValue (incoming)
-		playerConfig.Outgoing[groupmap[i]] = UIDropDownMenu_GetSelectedValue (outgoing)
+		if incoming then
+			if incoming.GetValue then
+				playerConfig.Incoming[groupmap[i]] = incoming:GetValue()
+			else
+				playerConfig.Incoming[groupmap[i]] = UIDropDownMenu_GetSelectedValue(incoming)
+			end
+		end
+		if outgoing then
+			if outgoing.GetValue then
+				playerConfig.Outgoing[groupmap[i]] = outgoing:GetValue()
+			else
+				playerConfig.Outgoing[groupmap[i]] = UIDropDownMenu_GetSelectedValue(outgoing)
+			end
+		end
 	end
 
 	playerConfig.ForceWhispers = ChatSoundsOptionsFrameForceWhispersCheckBox:GetChecked()
@@ -109,8 +122,20 @@ function ChatSoundsOptionsFrame_OnDefaults(self)
 		local incoming = _G["ChatSoundsOptionsFrameGroup"..i.."Incoming"]
 		local outgoing = _G["ChatSoundsOptionsFrameGroup"..i.."Outgoing"]
 
-		UIDropDownMenu_SetSelectedValue(incoming, ChatSounds_Defaults.Incoming[groupmap[i]], 0)
-		UIDropDownMenu_SetSelectedValue(outgoing, ChatSounds_Defaults.Outgoing[groupmap[i]], 0)
+		if incoming then
+			if incoming.SetValue then
+				incoming:SetValue(ChatSounds_Defaults.Incoming[groupmap[i]])
+			else
+				UIDropDownMenu_SetSelectedValue(incoming, ChatSounds_Defaults.Incoming[groupmap[i]], 0)
+			end
+		end
+		if outgoing then
+			if outgoing.SetValue then
+				outgoing:SetValue(ChatSounds_Defaults.Outgoing[groupmap[i]])
+			else
+				UIDropDownMenu_SetSelectedValue(outgoing, ChatSounds_Defaults.Outgoing[groupmap[i]], 0)
+			end
+		end
 	end
 
 	ChatSoundsOptionsFrameForceWhispersCheckBox:SetChecked(ChatSounds_Defaults.ForceWhispers)

--- a/ChatSoundsOptionsFrame.lua
+++ b/ChatSoundsOptionsFrame.lua
@@ -59,44 +59,52 @@ function ChatSoundsOptionsFrame_OnLoad (self)
 	tinsert(UISpecialFrames, self:GetName());
 	self:SetBackdropColor(0,0,0,1)
 	self:SetClampedToScreen(true);
-	self:RegisterEvent("VARIABLES_LOADED");
-end
 
-function ChatSoundsOptionsFrame_OnEvent(self, event, ...)
-	local arg1 = ...;
-	if (event == "VARIABLES_LOADED") then
-		local that = self
-		self = ChatMenu
-		UIMenu_AddButton(self, "ChatSounds", nil, ChatSoundsOptionsFrame_Show)
-		self = that
+	self.name = "ChatSounds"
+	self.okay = ChatSoundsOptionsFrame_OnOkay
+	self.cancel = ChatSoundsOptionsFrame_OnCancel
+	self.default = ChatSoundsOptionsFrame_OnDefaults
+	self.refresh = ChatSoundsOptionsFrame_OnShow
+
+	if InterfaceOptions_AddCategory then
+		InterfaceOptions_AddCategory(self)
 	end
 end
 
 function ChatSoundsOptionsFrame_OnShow(self)
+	ChatSounds_InitConfig()
+	local playerConfig = ChatSounds_Config[ChatSounds_Player]
 	for i = 1, 11 do
 		local incoming = _G["ChatSoundsOptionsFrameGroup"..i.."Incoming"]
 		local outgoing = _G["ChatSoundsOptionsFrameGroup"..i.."Outgoing"]
 
-		UIDropDownMenu_SetSelectedValue(incoming, ChatSounds_Config[ChatSounds_Player].Incoming[groupmap[i]], 0)
-		UIDropDownMenu_SetSelectedValue(outgoing, ChatSounds_Config[ChatSounds_Player].Outgoing[groupmap[i]], 0)
+		UIDropDownMenu_SetSelectedValue(incoming, playerConfig.Incoming[groupmap[i]], 0)
+		UIDropDownMenu_SetSelectedValue(outgoing, playerConfig.Outgoing[groupmap[i]], 0)
 	end
 
-	ChatSoundsOptionsFrameForceWhispersCheckBox:SetChecked (ChatSounds_Config[ChatSounds_Player].ForceWhispers)
+	ChatSoundsOptionsFrameForceWhispersCheckBox:SetChecked (playerConfig.ForceWhispers)
+end
+
+function ChatSoundsOptionsFrame_OnCancel(self)
+	HideUIPanel(self)
 end
 
 function ChatSoundsOptionsFrame_OnOkay(self)
+	ChatSounds_InitConfig()
+	local playerConfig = ChatSounds_Config[ChatSounds_Player]
 	for i = 1, 11 do
 		local incoming = _G["ChatSoundsOptionsFrameGroup"..i.."Incoming"]
 		local outgoing = _G["ChatSoundsOptionsFrameGroup"..i.."Outgoing"]
 
-		ChatSounds_Config[ChatSounds_Player].Incoming[groupmap[i]] = UIDropDownMenu_GetSelectedValue (incoming)
-		ChatSounds_Config[ChatSounds_Player].Outgoing[groupmap[i]] = UIDropDownMenu_GetSelectedValue (outgoing)
+		playerConfig.Incoming[groupmap[i]] = UIDropDownMenu_GetSelectedValue (incoming)
+		playerConfig.Outgoing[groupmap[i]] = UIDropDownMenu_GetSelectedValue (outgoing)
 	end
 
-	ChatSounds_Config[ChatSounds_Player].ForceWhispers = ChatSoundsOptionsFrameForceWhispersCheckBox:GetChecked()
+	playerConfig.ForceWhispers = ChatSoundsOptionsFrameForceWhispersCheckBox:GetChecked()
 end
 
 function ChatSoundsOptionsFrame_OnDefaults(self)
+	ChatSounds_InitConfig()
 	for i = 1, 11 do
 		local incoming = _G["ChatSoundsOptionsFrameGroup"..i.."Incoming"]
 		local outgoing = _G["ChatSoundsOptionsFrameGroup"..i.."Outgoing"]
@@ -108,6 +116,4 @@ function ChatSoundsOptionsFrame_OnDefaults(self)
 	ChatSoundsOptionsFrameForceWhispersCheckBox:SetChecked(ChatSounds_Defaults.ForceWhispers)
 end
 
-function ChatSoundsOptionsFrame_Show(self)
-	ChatSoundsOptionsFrame:Show()
-end
+

--- a/ChatSoundsOptionsFrame.lua
+++ b/ChatSoundsOptionsFrame.lua
@@ -12,9 +12,11 @@ groupmap[10] = "BNWHISPER"
 groupmap[11] = "CHANNEL"
 
 function ChatSoundsDropDown_OnShow (self)
-	local menu = {text = "ChatSounds Sounds", whileDead = 1, isNotSelectable = true}
-	menu.func = ChatSoundsDropDown_OnClick
+	UIDropDownMenu_SetSelectedID(self, 1, 0)
+	UIDropDownMenu_Initialize(self, ChatSoundsDropDown_Init)
+end
 
+function ChatSoundsDropDown_Init(self)
 	local sound = {}
 	local i = 1
 	for name, value in pairs(ChatSounds_Sound) do
@@ -24,21 +26,33 @@ function ChatSoundsDropDown_OnShow (self)
 
 	table.sort(sound)
 
-	-- Add "None" option
-	table.insert(menu, {text = "None", value = nil, func = ChatSoundsDropDown_OnClick})
+	local entry;
+	entry = UIDropDownMenu_CreateInfo();
 
-	-- Add all sounds
+	entry.text    = "None"
+	entry.value   = nil
+	entry.func    = ChatSoundsDropDown_OnClick
+	entry.checked = false
+	entry.owner   = self
+
+	UIDropDownMenu_AddButton(entry)
+
 	for index, value in pairs(sound) do
-		table.insert(menu, {text = value, value = value, func = ChatSoundsDropDown_OnClick})
+
+		entry.text    = value
+		entry.value   = value
+		entry.func    = ChatSoundsDropDown_OnClick
+		entry.checked = false
+		entry.owner   = self
+
+		UIDropDownMenu_AddButton(entry)
 	end
 
-	UIDropDownMenu_Initialize(self, function() UIDropDownMenu_AddButtons(menu) end, "MENU")
 end
 
 function ChatSoundsDropDown_OnClick(self)
-	if self.value then
-		ChatSounds_PlaySound(self.value)
-	end
+	UIDropDownMenu_SetSelectedValue(self.owner, self.value, 0);
+	ChatSounds_PlaySound(self.value);
 end
 
 function ChatSoundsOptionsFrame_OnLoad (self)

--- a/ChatSoundsOptionsFrame.xml
+++ b/ChatSoundsOptionsFrame.xml
@@ -60,10 +60,6 @@
 		<Size>
 			<AbsDimension x="433" y="478"/>
 		</Size>
-		<TitleRegion>
-			<Size x="400" y="100"/>
-			<Anchors><Anchor point="TOP"/></Anchors>
-		</TitleRegion>
 		<Anchors>
 			<Anchor point="CENTER"/>
 		</Anchors>
@@ -222,7 +218,7 @@
 				</Anchors>
 			</Frame>
 			
-			<CheckButton name="$parentForceWhispersCheckBox" inherits="OptionsCheckButtonTemplate">
+			<CheckButton name="$parentForceWhispersCheckBox" inherits="InterfaceOptionsCheckButtonTemplate">
 				<Anchors>
 					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeTo="$parentGroup11">
 						<Offset>
@@ -232,7 +228,7 @@
 				</Anchors>
 			</CheckButton>
 
-			<Button name="$parentDefaultsButton" inherits="OptionsButtonTemplate" text="DEFAULTS">
+			<Button name="$parentDefaultsButton" inherits="UIPanelButtonTemplate" text="DEFAULTS">
 				<Size>
 					<AbsDimension x="100" y="21"/>
 				</Size>
@@ -250,7 +246,7 @@
 					</OnClick>
 				</Scripts>
 			</Button>
-			<Button name="$parentCancelButton" inherits="OptionsButtonTemplate" text="CANCEL">
+			<Button name="$parentCancelButton" inherits="UIPanelButtonTemplate" text="CANCEL">
 				<Size>
 					<AbsDimension x="100" y="21"/>
 				</Size>
@@ -268,7 +264,7 @@
 					</OnClick>
 				</Scripts>
 			</Button>
-			<Button name="$parentOkayButton" inherits="OptionsButtonTemplate" text="OKAY">
+			<Button name="$parentOkayButton" inherits="UIPanelButtonTemplate" text="OKAY">
 				<Size>
 					<AbsDimension x="100" y="21"/>
 				</Size>
@@ -313,9 +309,11 @@
 				ChatSoundsOptionsFrameGroup10Label:SetText("BNET Whispers");
 				ChatSoundsOptionsFrameGroup11Label:SetText("Custom");
 
-				ChatSoundsOptionsFrameForceWhispersCheckBoxText:SetText("Always play incoming whisper sounds.");
-				ChatSoundsOptionsFrameForceWhispersCheckBoxText:SetTextHeight(12);
-				ChatSoundsOptionsFrameForceWhispersCheckBoxText:SetTextColor(1.0, 1.0, 0.0);
+				if ChatSoundsOptionsFrameForceWhispersCheckBoxText then
+					ChatSoundsOptionsFrameForceWhispersCheckBoxText:SetText("Always play incoming whisper sounds.");
+					ChatSoundsOptionsFrameForceWhispersCheckBoxText:SetTextHeight(12);
+					ChatSoundsOptionsFrameForceWhispersCheckBoxText:SetTextColor(1.0, 1.0, 0.0);
+				end
 
 				self:RegisterForDrag("LeftButton");
 			</OnLoad>
@@ -332,17 +330,18 @@
 					<AbsValue val="32"/>
 				</EdgeSize>
 			</Backdrop> -->
-			<OnEvent>
-				ChatSoundsOptionsFrame_OnEvent (self, event, ...);
-			</OnEvent>
 			<OnShow>
 				ChatSoundsOptionsFrame_OnShow ( self );
 				-- UpdateMicroButtons ( self );
-				Disable_BagButtons ( self );
+				if Disable_BagButtons then
+					Disable_BagButtons ( self );
+				end
 			</OnShow>
 			<OnHide>
 				-- UpdateMicroButtons ( self );
-				Enable_BagButtons ( self );
+				if Enable_BagButtons then
+					Enable_BagButtons ( self );
+				end
 			</OnHide>
 		</Scripts>
 	</Frame>

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ ChatSounds adds customizable audio cues for chat events (Guild, Party, Raid, whi
 - Select distinct incoming/outgoing sounds per channel via the Interface Options entry that now appears under `AddOns > ChatSounds`.
 - Use `/chatsounds <custom channel>` to toggle custom channel blacklisting.
 
-## Recent updates (Nov 28, 2025)
+## Recent updates
+### Nov 28, 2025
 - Registered the options window through `InterfaceOptions_AddCategory` and made `/chatsounds` invoke `InterfaceOptionsFrame_OpenToCategory` when available.
 - Replaced removed UI templates (`OptionsButtonTemplate`, `OptionsCheckButtonTemplate`, `TitleRegion`) with modern equivalents and safely guarded the bag-button helpers/text widgets that may not exist anymore.
 - Made sure the configuration tables are initialized before showing or saving settings so the new interface code no longer hits nil globals.
+### Dec 3, 2025
+- Delay `hooksecurefunc("ChatFrame_OnEvent")` until the core chat frame handler exists, with a `PLAYER_LOGIN` fallback so the hook runs without causing the `hooksecurefunc(): ChatFrame_OnEvent is not a function` error.
 
 ## Notes
 - Sounds live under the `Sounds/` directory; add your own by editing `SoundList.lua` and placing files in that folder.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# ChatSounds Addon
+
+ChatSounds adds customizable audio cues for chat events (Guild, Party, Raid, whispers, BN whispers, and custom channels). Each event can play either one of the bundled .mp3 clips or one of the built-in Blizzard sounds defined in `SoundList.lua`.
+
+## Installation
+1. Drop the `ChatSounds` folder into your `Interface/AddOns` directory.
+2. Ensure `ChatSounds.toc` and `ChatSounds.lua` (plus the supporting XML and sound assets) are present.
+3. Restart or `/reload` the WoW UI.
+
+## Usage
+- Type `/chatsounds` to open the options panel or `/chatsounds !help` for command references.
+- Select distinct incoming/outgoing sounds per channel via the Interface Options entry that now appears under `AddOns > ChatSounds`.
+- Use `/chatsounds <custom channel>` to toggle custom channel blacklisting.
+
+## Recent updates (Nov 28, 2025)
+- Registered the options window through `InterfaceOptions_AddCategory` and made `/chatsounds` invoke `InterfaceOptionsFrame_OpenToCategory` when available.
+- Replaced removed UI templates (`OptionsButtonTemplate`, `OptionsCheckButtonTemplate`, `TitleRegion`) with modern equivalents and safely guarded the bag-button helpers/text widgets that may not exist anymore.
+- Made sure the configuration tables are initialized before showing or saving settings so the new interface code no longer hits nil globals.
+
+## Notes
+- Sounds live under the `Sounds/` directory; add your own by editing `SoundList.lua` and placing files in that folder.
+- The addon now syncs with Blizzard's current API, so the options panel should load cleanly on Retail clients.


### PR DESCRIPTION
- Registered the options window through `InterfaceOptions_AddCategory` and made `/chatsounds` invoke `InterfaceOptionsFrame_OpenToCategory` when available.
- Replaced removed UI templates (`OptionsButtonTemplate`, `OptionsCheckButtonTemplate`, `TitleRegion`) with modern equivalents and safely guarded the bag-button helpers/text widgets that may not exist anymore.
- Made sure the configuration tables are initialized before showing or saving settings so the new interface code no longer hits nil globals.